### PR TITLE
1.0.0-SNAPSHOT does not exist.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -76,7 +76,7 @@ Add the following dependency to your `pom.xml` file:
 <dependency>
   <groupId>com.datastax.astra</groupId>
   <artifactId>astra-db-java</artifactId>
-  <version>1.0.0-SNAPSHOT</version>
+  <version>1.0.0</version>
 </dependency>
 ```
 


### PR DESCRIPTION
As of 20240413, valid versions are:

1.0.0
1.0.0-beta1