### PR TITLE
Modify org name and url for copyright

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -488,8 +488,8 @@
 
     <!-- Organization -->
     <organization>
-        <name>DataStax</name>
-        <url>https://www.datastax.com</url>
+        <name>DataStax, an IBM Company</name>
+        <url>https://www.ibm.com/products/datastax</url>
     </organization>
 
     <!-- Release the client with Apache License -->


### PR DESCRIPTION
I _think_ that the copyright info in the autogenerated Java client docs is being pulled from the organization name and URL in the pom.xml file. The copyright should now be: © 2025 DataStax, an IBM Company. This PR updates the organization name and URL in the pom.xml file in an attempt to update the copyright in the autogenerated Java client docs.